### PR TITLE
Add initial support for invalidated entities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.3.2
 Flask==0.10.1
 Flask-SocketIO==0.3.7
-gevent==1.0.1
+gevent==1.0.2
 gevent-socketio==0.3.6
 gevent-websocket==0.9.3
 greenlet==0.4.2

--- a/src/app/templates/resource_to_activity.q
+++ b/src/app/templates/resource_to_activity.q
@@ -16,6 +16,15 @@ SELECT DISTINCT ?entity ?entity_type ?entity_label ?activity ?activity_type ?act
 			?activity	prov:qualifiedUsage ?qu .
 			?qu			prov:entity ?entity .
 	  	}
+		UNION
+		{ ?activity prov:invalidated ?entity . }
+		UNION
+		{ ?entity prov:wasInvalidatedBy ?activity . }
+	  	UNION
+	  	{ 
+			?activity	prov:qualifiedInvalidation ?qi .
+			?qi			prov:entity ?entity .
+	  	}
     	OPTIONAL { ?activity rdf:type ?activity_type .
     			 ?activity_type rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
     			 FILTER(!isBlank(?activity_type)) }


### PR DESCRIPTION
Add checks for invalidated entities.  Per the spec “Any generation or
usage of an entity precedes its invalidation”, so I’ve added the check
to resource_to_activity since an invalidation should be an input to the
invalidating activity.