### PR TITLE
Fixing link to sha1 lib

### DIFF
--- a/src/app/templates/base.html
+++ b/src/app/templates/base.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('.static',filename='css/select2.css') }}" />
     <link rel="stylesheet" href="{{ url_for('.static',filename='css/select2-bootstrap.css') }}" />
     <script type="application/x-javascript" src="http://code.jquery.com/jquery-latest.js"></script>
+	<script type="application/x-javascript" src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/components/core-min.js"></script>
     
     <script>
     // Make sure that we know what modules to load from the service response
@@ -26,7 +27,7 @@
                 $.getScript("{{ url_for('.static',filename='js/jquery.fittext.js') }}").success(function(){
                     console.log("jQuery Fittext loaded");
                     console.log("Loading SHA1");
-                    $.getScript("http://crypto-js.googlecode.com/svn/tags/3.1.2/build/rollups/sha1.js").success(function(){
+                    $.getScript("https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/components/sha1.js").success(function(){
                         console.log("SHA1 loaded");
                         console.log("Loading Socket IO");
                         $.getScript("http://cdnjs.cloudflare.com/ajax/libs/socket.io/0.9.16/socket.io.min.js").success(function(){


### PR DESCRIPTION
Seem like link to
crypto-js.googlecode.com/svn/tags/3.1.2/build/rollups/sha1.js doesn't
work anymore

note this means that http://provoviz.org/ doesn't work either