### PR TITLE
Switches to https for jquery-latest.

### DIFF
--- a/src/app/templates/base.html
+++ b/src/app/templates/base.html
@@ -3,14 +3,14 @@
 <html>
 <head>
     <title>PROV Provenance Visualizer</title>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="{{ url_for('.static',filename='css/bootstrap.min.css') }}" />
     <!-- <link rel="stylesheet" href="{{ url_for('.static',filename='css/bootstrap-theme.min.css') }}" /> -->
-	<link rel="stylesheet" href="{{ url_for('.static',filename='css/provoviz.css') }}" />
+    <link rel="stylesheet" href="{{ url_for('.static',filename='css/provoviz.css') }}" />
     <link rel="stylesheet" href="{{ url_for('.static',filename='css/select2.css') }}" />
     <link rel="stylesheet" href="{{ url_for('.static',filename='css/select2-bootstrap.css') }}" />
-    <script type="application/x-javascript" src="http://code.jquery.com/jquery-latest.js"></script>
-	<script type="application/x-javascript" src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/components/core-min.js"></script>
+    <script type="application/x-javascript" src="https://code.jquery.com/jquery-latest.js"></script>
+    <script type="application/x-javascript" src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/components/core-min.js"></script>
     
     <script>
     // Make sure that we know what modules to load from the service response


### PR DESCRIPTION
Linking to http://code.jquery.com/jquery-latest.js not working in Chrome 79.